### PR TITLE
[Issue 23] Line Plot Mixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "serve": "wds --watch",
     "serve:prod": "cross-env MODE=prod npm run serve",
     "test": "npm run test:dev && npm run test:prod",
-    "test:build:watch": "tsc --project tsconfig.test.json --watch",
     "test:dev": "wtr",
     "test:watch": "wtr --watch",
     "test:prod": "cross-env MODE=prod wtr",

--- a/src/mixins/lit-axis.ts
+++ b/src/mixins/lit-axis.ts
@@ -12,7 +12,7 @@ type LineElements = Array<TemplateResult>;
 type LabelsArr = SVGTextElement[];
 
 export declare class LitAxisInterface {
-    renderAxis(axisData?: Axis<AxisData<AXIS_TYPE>>): unknown;
+    renderAxis(axisData?: Axis<AxisData<AXIS_TYPE>, AxisData<AXIS_TYPE>>): unknown;
 }
 
 interface LitGraphCoords {
@@ -31,7 +31,7 @@ const CONSTANTS = {
 const defaults = {
     x: { begin: 0, end: 9, interval: 1, type: 'number' },
     y: { begin: 0, end: 9, interval: 1, type: 'number' }
-} as Axis<AxisData<AXIS_TYPE.NUMBER>>;
+} as Axis<AxisData<AXIS_TYPE.NUMBER>, AxisData<AXIS_TYPE.NUMBER>>;
 
 export const LitAxisMixin = <T extends Constructor<LitElement>>(superClass: T) => {
     class LitAxisClass extends superClass {
@@ -224,7 +224,9 @@ export const LitAxisMixin = <T extends Constructor<LitElement>>(superClass: T) =
             return lineElements;
         }
 
-        renderAxis(axisData: Axis<AxisData<AXIS_TYPE>> = defaults): TemplateResult {
+        renderAxis(
+            axisData: Axis<AxisData<AXIS_TYPE>, AxisData<AXIS_TYPE>> = defaults
+            ): TemplateResult {
             const { x, y } = axisData;
 
             return (svg`

--- a/src/mixins/lit-axis.ts
+++ b/src/mixins/lit-axis.ts
@@ -1,12 +1,11 @@
 import { LitElement, nothing, svg, css, TemplateResult } from 'lit';
-import { Axis, AxisData, SingleAxisData } from '../types';
+import { AxisData, NUM_AXIS_TYPE, SingleAxisData } from '../types';
 import { AXIS, AXIS_TYPE, GRAPH } from '../constants';
 import { state } from 'lit/decorators.js';
 import { ref, createRef } from 'lit/directives/ref.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T = {}> = new (...args: any[]) => T;
-type DateNum = AXIS_TYPE.DATE | AXIS_TYPE.NUMBER;
 type LabelRenderer = (val: number) => string | TemplateResult;
 type LineElements = Array<TemplateResult>;
 type LabelsArr = SVGTextElement[];
@@ -117,7 +116,7 @@ export const LitAxisMixin = <T extends Constructor<LitElement>>(superClass: T) =
                 return (val: number) => new Date(val).toLocaleDateString();
             }
         }
-        private generateDateNumLabels(data: SingleAxisData<DateNum>, 
+        private generateDateNumLabels(data: SingleAxisData<NUM_AXIS_TYPE>, 
             lineElements: LineElements): void {
             const labelRenderer = this.generateLabelRenderer(data.type, data.interval);
             

--- a/src/mixins/lit-axis.ts
+++ b/src/mixins/lit-axis.ts
@@ -1,5 +1,5 @@
 import { LitElement, nothing, svg, css, TemplateResult } from 'lit';
-import { Axis, AxisData, AxisCoords } from '../types';
+import { Axis, AxisData, SingleAxisData } from '../types';
 import { AXIS, AXIS_TYPE, GRAPH } from '../constants';
 import { state } from 'lit/decorators.js';
 import { ref, createRef } from 'lit/directives/ref.js';
@@ -12,12 +12,7 @@ type LineElements = Array<TemplateResult>;
 type LabelsArr = SVGTextElement[];
 
 export declare class LitAxisInterface {
-    renderAxis(axisData?: Axis<AxisData<AXIS_TYPE>, AxisData<AXIS_TYPE>>): unknown;
-}
-
-interface LitGraphCoords {
-    graph?: AxisCoords;
-    viewBox?: AxisCoords;
+    renderAxis(axisData?: AxisData<AXIS_TYPE, AXIS_TYPE>): unknown;
 }
 
 const CONSTANTS = {
@@ -31,7 +26,7 @@ const CONSTANTS = {
 const defaults = {
     x: { begin: 0, end: 9, interval: 1, type: 'number' },
     y: { begin: 0, end: 9, interval: 1, type: 'number' }
-} as Axis<AxisData<AXIS_TYPE.NUMBER>, AxisData<AXIS_TYPE.NUMBER>>;
+} as AxisData<AXIS_TYPE.NUMBER, AXIS_TYPE.NUMBER>;
 
 export const LitAxisMixin = <T extends Constructor<LitElement>>(superClass: T) => {
     class LitAxisClass extends superClass {
@@ -81,7 +76,7 @@ export const LitAxisMixin = <T extends Constructor<LitElement>>(superClass: T) =
             `);
         }
 
-        private generateLabels(data: AxisData<AXIS_TYPE>, lineElements: LineElements){
+        private generateLabels(data: SingleAxisData<AXIS_TYPE>, lineElements: LineElements){
             if (Array.isArray(data)) {
                 this.generateStrLabels(data, lineElements);
             } else {
@@ -122,7 +117,8 @@ export const LitAxisMixin = <T extends Constructor<LitElement>>(superClass: T) =
                 return (val: number) => new Date(val).toLocaleDateString();
             }
         }
-        private generateDateNumLabels(data: AxisData<DateNum>, lineElements: LineElements): void {
+        private generateDateNumLabels(data: SingleAxisData<DateNum>, 
+            lineElements: LineElements): void {
             const labelRenderer = this.generateLabelRenderer(data.type, data.interval);
             
             for (let i = data.begin; i < data.end + 1; i += data.interval) {
@@ -189,9 +185,8 @@ export const LitAxisMixin = <T extends Constructor<LitElement>>(superClass: T) =
         }
 
         private updateMeasurementLabels(axis: AXIS): void {
-            const graphAxisCoords = (this as unknown as LitGraphCoords)?.graph || null;
             const isYAxis = axis === AXIS.Y;
-            const END = graphAxisCoords ? graphAxisCoords[axis].END :  GRAPH[axis].END;
+            const { END } = GRAPH[axis];
             const labels = this.labels[axis].value?.querySelectorAll('text');
             
 
@@ -216,7 +211,7 @@ export const LitAxisMixin = <T extends Constructor<LitElement>>(superClass: T) =
             
         }
 
-        private generateAxis(data: AxisData<AXIS_TYPE>, axis: AXIS): LineElements {
+        private generateAxis(data: SingleAxisData<AXIS_TYPE>, axis: AXIS): LineElements {
             const lineElements: LineElements = []; 
             this.generateLine(axis, lineElements);
             this.generateLabels(data, lineElements);
@@ -225,7 +220,7 @@ export const LitAxisMixin = <T extends Constructor<LitElement>>(superClass: T) =
         }
 
         renderAxis(
-            axisData: Axis<AxisData<AXIS_TYPE>, AxisData<AXIS_TYPE>> = defaults
+            axisData: AxisData<AXIS_TYPE, AXIS_TYPE> = defaults
             ): TemplateResult {
             const { x, y } = axisData;
 

--- a/src/mixins/lit-grid.ts
+++ b/src/mixins/lit-grid.ts
@@ -5,7 +5,7 @@ import { Axis } from '../types';
 type Constructor<T = {}> = new (...args: any[]) => T;
 
 export declare class LitGridInterface {
-    renderGrid(axisLengths?: Axis<number>): unknown;
+    renderGrid(axisLengths?: Axis<number, number>): unknown;
 }
 
 export const LitGridMixin = <T extends Constructor<LitElement>>(superClass: T) => {
@@ -39,7 +39,7 @@ export const LitGridMixin = <T extends Constructor<LitElement>>(superClass: T) =
             return lineElements;
         }
 
-        renderGrid(axisLengths: Axis<number> = { x: 10, y: 10 }) {
+        renderGrid(axisLengths: Axis<number, number> = { x: 10, y: 10 }) {
             const { x, y } = axisLengths;
             return svg`
                 ${this.renderXAxisLines(x)}

--- a/src/mixins/lit-line-plot.ts
+++ b/src/mixins/lit-line-plot.ts
@@ -1,6 +1,6 @@
 import { LitElement, svg } from 'lit';
 import { AXIS, AXIS_TYPE, GRAPH } from '../constants';
-import { PlotData, Axis, AxisType, AxisData, SingleAxisData } from '../types';
+import { PlotData, Axis, AxisType, AxisData, SingleAxisData, NUM_AXIS_TYPE } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T = {}> = new (...args: any[]) => T;
@@ -27,21 +27,28 @@ export const LitLinePlotMixin = <T extends Constructor<LitElement>>(superClass: 
         }
 
         private generateNumAxisPosition(
-            plot: AxisType, data: SingleAxisData<AXIS_TYPE>, axis: AXIS
+            plot: number, data: SingleAxisData<NUM_AXIS_TYPE>, axis: AXIS
         ): number {
             const { START, END } = GRAPH[axis];
 
-            return 0;
+            return (END -START) * (data.end - data.begin) / plot;
         }
 
         private getAxisPosition(
             plot: AxisType, data: SingleAxisData<AXIS_TYPE>, axis: AXIS
         ): number {
-            if (Array.isArray(data) && typeof plot === 'string') {
-                return this.generateStringAxisPosition(plot, data, axis);
-            } else {
-                return this.generateNumAxisPosition(plot, data, axis);
+            if (Array.isArray(data)) {
+                if (typeof plot === 'string') {
+                    return this.generateStringAxisPosition(plot, data, axis);
+                }
+                throw new Error('Axis Data is of type string but plot is Number');
             }
+
+            if (typeof plot !== 'number') {
+                throw new Error('Axis Data is of type number but plot is String');
+            }
+
+            return this.generateNumAxisPosition(plot, data, axis);
         }
 
         private getPosition(

--- a/src/mixins/lit-line-plot.ts
+++ b/src/mixins/lit-line-plot.ts
@@ -13,11 +13,17 @@ export const LitLinePlotMixin = <T extends Constructor<LitElement>>(superClass: 
     class LitLinePlotClass extends superClass {
 
         private generateStringAxisPosition(
-            plot: AxisType, data: SingleAxisData<AXIS_TYPE>, axis: AXIS
+            plot: string, data: SingleAxisData<AXIS_TYPE.STRING>, axis: AXIS
         ): number {
             const { START, END } = GRAPH[axis];
 
-            return 0;
+            const plotIndex = data.indexOf(plot);
+
+            if(plotIndex < 0) {
+                throw new Error('String Plot doesnt exist in axis data');
+            }
+
+            return (END - START) * (plotIndex/data.length);
         }
 
         private generateNumAxisPosition(
@@ -31,7 +37,7 @@ export const LitLinePlotMixin = <T extends Constructor<LitElement>>(superClass: 
         private getAxisPosition(
             plot: AxisType, data: SingleAxisData<AXIS_TYPE>, axis: AXIS
         ): number {
-            if (Array.isArray(data)) {
+            if (Array.isArray(data) && typeof plot === 'string') {
                 return this.generateStringAxisPosition(plot, data, axis);
             } else {
                 return this.generateNumAxisPosition(plot, data, axis);

--- a/src/mixins/lit-line-plot.ts
+++ b/src/mixins/lit-line-plot.ts
@@ -1,6 +1,6 @@
-import { LitElement, svg, TemplateResult } from 'lit';
+import { css, LitElement, svg, TemplateResult } from 'lit';
 import { AXIS, AXIS_TYPE, GRAPH } from '../constants';
-import { PlotData, Axis, AxisType, AxisData, SingleAxisData, NUM_AXIS_TYPE } from '../types';
+import { PlotData, AxisType, AxisData, SingleAxisData, NUM_AXIS_TYPE } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T = {}> = new (...args: any[]) => T;
@@ -12,6 +12,16 @@ export declare class LitLinePlotInterface {
 
 export const LitLinePlotMixin = <T extends Constructor<LitElement>>(superClass: T) => {
     class LitLinePlotClass extends superClass {
+
+        static styles = (css`
+            #PlotCircles circle {
+                r: 1.5;
+            }
+
+            #PlotLines line {
+                stroke: black;
+            }
+        `);
 
         private generateStringAxisPosition(
             plot: string, data: SingleAxisData<AXIS_TYPE.STRING>, axis: AXIS

--- a/src/mixins/lit-line-plot.ts
+++ b/src/mixins/lit-line-plot.ts
@@ -30,8 +30,13 @@ export const LitLinePlotMixin = <T extends Constructor<LitElement>>(superClass: 
             plot: number, data: SingleAxisData<NUM_AXIS_TYPE>, axis: AXIS
         ): number {
             const { START, END } = GRAPH[axis];
+            const position = (END - START) *  plot / (data.end - data.begin);
 
-            return (END -START) * (data.end - data.begin) / plot;
+            if (axis === AXIS.Y) {
+                return END - position;
+            }
+
+            return position;
         }
 
         private getAxisPosition(

--- a/src/mixins/lit-line-plot.ts
+++ b/src/mixins/lit-line-plot.ts
@@ -1,0 +1,64 @@
+import { LitElement, svg } from 'lit';
+import { AXIS, AXIS_TYPE, GRAPH } from '../constants';
+import { PlotData, Axis, AxisType, AxisData, SingleAxisData } from '../types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+export declare class LitLinePlotInterface {
+    renderLinePlot(data: PlotData, axisData: AxisData<AXIS_TYPE, AXIS_TYPE>): unknown;
+}
+
+export const LitLinePlotMixin = <T extends Constructor<LitElement>>(superClass: T) => {
+    class LitLinePlotClass extends superClass {
+
+        private generateStringAxisPosition(
+            plot: AxisType, data: SingleAxisData<AXIS_TYPE>, axis: AXIS
+        ): number {
+            const { START, END } = GRAPH[axis];
+
+            return 0;
+        }
+
+        private generateNumAxisPosition(
+            plot: AxisType, data: SingleAxisData<AXIS_TYPE>, axis: AXIS
+        ): number {
+            const { START, END } = GRAPH[axis];
+
+            return 0;
+        }
+
+        private getAxisPosition(
+            plot: AxisType, data: SingleAxisData<AXIS_TYPE>, axis: AXIS
+        ): number {
+            if (Array.isArray(data)) {
+                return this.generateStringAxisPosition(plot, data, axis);
+            } else {
+                return this.generateNumAxisPosition(plot, data, axis);
+            }
+        }
+
+        private getPosition(
+            plot: Axis<AxisType, AxisType>, 
+            axisData: AxisData<AXIS_TYPE, AXIS_TYPE> ): Axis<number, number> {
+            
+                return {
+                    x: this.getAxisPosition(plot.x, axisData.x, AXIS.X),
+                    y: this.getAxisPosition(plot.y, axisData.y, AXIS.Y)
+                };
+        }
+
+        renderLinePlot(data: PlotData, axisData: AxisData<AXIS_TYPE, AXIS_TYPE>) {
+            return (svg`
+                <g>
+                    ${data.map((plot) => {
+                        const { x, y } = this.getPosition(plot, axisData);
+                        return (svg`<circle cx="${x}" cy="${y}" r="2">`);
+                    })}
+                </g>
+            `);
+        }
+    }
+
+    return LitLinePlotClass as Constructor<LitLinePlotInterface> & T;
+};

--- a/src/test/mixins/lit-axis_test.ts
+++ b/src/test/mixins/lit-axis_test.ts
@@ -3,7 +3,7 @@ import { html, LitElement } from 'lit';
 import { timeout } from '../helpers';
 import { AXIS_TYPE } from '../../constants';
 import { LitAxisMixin } from '../../mixins/lit-axis';
-import { AxisData } from '../../types';
+import {  SingleAxisData } from '../../types';
 import { ref, createRef } from 'lit/directives/ref.js';
 
 const expects = {
@@ -27,11 +27,11 @@ function testDefaultLabels(label: Element, index: number) {
     assert.equal(Number(label.textContent), expects.default[index], 'Label text wrong');
 }
 
-function testDateLabels(label, index) {
+function testDateLabels(label: Element, index: number) {
     const tspans = label.querySelectorAll('tspan');
     assert.equal(tspans.length, 2, 'Inner TSpans did not render');
-    assert.equal(tspans[0].textContent.trim(), expects.dates[index][0], 'First TSpan text wrong');
-    assert.equal(tspans[1].textContent.trim(), expects.dates[index][1], 'Second TSpan text wrong');
+    assert.equal(tspans[0]?.textContent?.trim(), expects.dates[index][0], '1st TSpan text wrong');
+    assert.equal(tspans[1]?.textContent?.trim(), expects.dates[index][1], '2nd TSpan text wrong');
 }
 
 class Numbers extends LitAxisMixin(LitElement) {
@@ -73,7 +73,7 @@ class Dates extends LitAxisMixin(LitElement) {
             end,
             interval: (end - begin) / 10,
             type: AXIS_TYPE.DATE
-        } as AxisData<AXIS_TYPE.DATE>;
+        } as SingleAxisData<AXIS_TYPE.DATE>;
         const payload = {
             y: axis,
             x: axis

--- a/src/test/mixins/lit-line-plot_test.ts
+++ b/src/test/mixins/lit-line-plot_test.ts
@@ -1,0 +1,55 @@
+import { assert, fixture } from '@open-wc/testing';
+import { LitLinePlotMixin } from '../../mixins/lit-line-plot';
+import { html, LitElement } from 'lit';
+import { AxisData } from '../../types';
+import { AXIS_TYPE } from '../../constants';
+
+class Numbers extends LitLinePlotMixin(LitElement) {
+    private plot = [
+        {x: 0, y: 0},
+        {x: 1, y: 1},
+        {x: 2, y: 2},
+        {x: 3, y: 3},
+        {x: 4, y: 4},
+        {x: 5, y: 5},
+        {x: 6, y: 6},
+        {x: 7, y: 7},
+        {x: 8, y: 8},
+        {x: 9, y: 9},
+    ];
+
+    private axisData = {
+        x: {begin: 0, end: 9, interval: 1, type: 'number'},
+        y: {begin: 0, end: 9, interval: 1, type: 'number'}
+    } as AxisData<AXIS_TYPE.NUMBER, AXIS_TYPE.NUMBER>;
+    
+    override render() {
+        return (html`
+            <svg
+                height="300px"
+                width="300px"
+                viewBox="0 0 150 150">
+                    ${this.renderLinePlot(this.plot, this.axisData)}
+            </svg>
+        `);
+    }
+}
+customElements.define('test-numbers', Numbers);
+
+suite('lit-line-plot mixin', ()=> {
+    
+    test('is defined', () => {
+        const el = document.createElement('test-numbers');
+        assert.instanceOf(el, Numbers);
+        assert.exists((el as Numbers).renderLinePlot);
+    });
+
+    test('renders with numbers', async () => {
+        const el: LitElement = await fixture(html`<test-numbers></test-numbers>`);
+        const plotPoints = el.renderRoot.querySelectorAll('circle');
+        const plotLines = el.renderRoot.querySelectorAll('line');
+
+        assert.lengthOf(plotPoints, 10, 'Expected number of plot points to equal 10');
+        assert.lengthOf(plotLines, 9, 'Expected number of line points to equal 9');
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ export type Axis<T, U> = {
     y: U;
 };
 
+export type NUM_AXIS_TYPE = Exclude<AXIS_TYPE, AXIS_TYPE.STRING>;
+
 export type SingleAxisData<T extends AXIS_TYPE> = 
 T extends AXIS_TYPE.STRING ? Array<string> : { 
     begin: number,
@@ -16,6 +18,6 @@ T extends AXIS_TYPE.STRING ? Array<string> : {
 export type AxisData<T extends AXIS_TYPE, U extends AXIS_TYPE> = 
     Axis<SingleAxisData<T>, SingleAxisData<U>>;
 
-export type AxisType = number | string | Date;
+export type AxisType = number | string;
 
 export type PlotData = Array<Axis<AxisType, AxisType>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
-import { AXIS, AXIS_TYPE } from './constants';
+import { AXIS_TYPE } from './constants';
 
 export type Axis<T, U> = { 
     x: T;
     y: U;
 };
 
-export type AxisData<T extends AXIS_TYPE> = 
+export type SingleAxisData<T extends AXIS_TYPE> = 
 T extends AXIS_TYPE.STRING ? Array<string> : { 
     begin: number,
     end: number,
@@ -13,15 +13,8 @@ T extends AXIS_TYPE.STRING ? Array<string> : {
     type: T
 };
 
-type SingleAxisCoords = {
-    START: number;
-    END: number;
-};
-
-export type AxisCoords = {
-    [AXIS.X]: SingleAxisCoords;
-    [AXIS.Y]: SingleAxisCoords;
-};
+export type AxisData<T extends AXIS_TYPE, U extends AXIS_TYPE> = 
+    Axis<SingleAxisData<T>, SingleAxisData<U>>;
 
 export type AxisType = number | string | Date;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 import { AXIS, AXIS_TYPE } from './constants';
 
-export type Axis<T> = { 
+export type Axis<T, U> = { 
     x: T;
-    y: T;
+    y: U;
 };
 
 export type AxisData<T extends AXIS_TYPE> = 
@@ -22,3 +22,7 @@ export type AxisCoords = {
     [AXIS.X]: SingleAxisCoords;
     [AXIS.Y]: SingleAxisCoords;
 };
+
+export type AxisType = number | string | Date;
+
+export type PlotData = Array<Axis<AxisType, AxisType>>;


### PR DESCRIPTION
Adding a mixin that will draw a line plot for the data in the SVG. Right now this mixin will plot the individual data points in the SVG with circle elements, and then draw lines connecting all of them. Changes include:
- adding mixin for line plot
- adding tests for line plot mixin
- adding types for line plot mixin
- updating and consolidating existing types

Fixes #23 